### PR TITLE
Fix newline issues and improve simulation process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+simulate:
+	# Concatenate all loglines ensuring a trailing newline between files
+	printf '' > organismos/homeostase_temperatura.logline
+	for f in genoma/*.logline; do \
+	cat "$$f" >> organismos/homeostase_temperatura.logline; \
+	printf '\n' >> organismos/homeostase_temperatura.logline; \
+	done
+	bash interpretador/simular_execucao.sh organismos/homeostase_temperatura.logline
+
+execute:
+	bash interpretador/executar_objetivo.sh organismos/homeostase_temperatura.logline
+
+validate:
+	python3 tests/validate_spans.py

--- a/genoma/encerramento_ciclo.logline
+++ b/genoma/encerramento_ciclo.logline
@@ -1,0 +1,2 @@
+version: 0.2
+call(encerrar_fluxo(), retry="linear", fallback="reset_seguro()")

--- a/genoma/leitura_sensor.logline
+++ b/genoma/leitura_sensor.logline
@@ -1,0 +1,2 @@
+version: 0.2
+call(sensor_temperatura(), retry="expo", fallback="sensor_backup()")

--- a/genoma/normalizacao_valor.logline
+++ b/genoma/normalizacao_valor.logline
@@ -1,0 +1,2 @@
+version: 0.2
+call(normalizar_temperatura(), fallback="valor_padrao()")

--- a/genoma/persistencia_dado.logline
+++ b/genoma/persistencia_dado.logline
@@ -1,0 +1,2 @@
+version: 0.2
+call(persistir_valor(), fallback="log_local()")

--- a/genoma/preditor_estado.logline
+++ b/genoma/preditor_estado.logline
@@ -1,0 +1,2 @@
+version: 0.2
+call(prever_estado(), simulate=true)


### PR DESCRIPTION
## Summary
- add missing newline in each `genoma/*.logline`
- improve the `simulate` target in the Makefile to insert newlines between concatenated files

## Testing
- `make simulate`
- `make validate` *(fails: JSON decode error)*

------
https://chatgpt.com/codex/tasks/task_b_6852cd9b5ef8832897f8dcc1d0a91fda